### PR TITLE
Use PUBLIC_ prefix for Google Maps env vars in Astro

### DIFF
--- a/src/nyguesser/NYGuesser.jsx
+++ b/src/nyguesser/NYGuesser.jsx
@@ -7,7 +7,7 @@ import FinalScreen from './components/FinalScreen'
 import './nyguesser.css'
 
 const TOTAL_ROUNDS = 5
-const API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY
+const API_KEY = import.meta.env.PUBLIC_GOOGLE_MAPS_API_KEY
 
 export default function NYGuesser() {
   const [gameState, setGameState] = useState('start')

--- a/src/nyguesser/components/FinalScreen.jsx
+++ b/src/nyguesser/components/FinalScreen.jsx
@@ -70,7 +70,7 @@ export default function FinalScreen({ results, onPlayAgain }) {
       <div className="final-map">
         <Map
           style={{ width: '100%', height: '100%' }}
-          mapId={import.meta.env.VITE_GOOGLE_MAPS_MAP_ID}
+          mapId={import.meta.env.PUBLIC_GOOGLE_MAPS_MAP_ID}
           defaultCenter={{ lat: 40.7128, lng: -74.006 }}
           defaultZoom={11}
           gestureHandling="cooperative"

--- a/src/nyguesser/components/GameScreen.jsx
+++ b/src/nyguesser/components/GameScreen.jsx
@@ -107,7 +107,7 @@ export default function GameScreen({ round, totalRounds, onSubmit }) {
         <div className="map-panel">
           <Map
             style={{ width: '100%', height: '100%' }}
-            mapId={import.meta.env.VITE_GOOGLE_MAPS_MAP_ID}
+            mapId={import.meta.env.PUBLIC_GOOGLE_MAPS_MAP_ID}
             defaultCenter={{ lat: 40.7128, lng: -74.006 }}
             defaultZoom={11} 
             onClick={handleMapClick}

--- a/src/nyguesser/components/ResultScreen.jsx
+++ b/src/nyguesser/components/ResultScreen.jsx
@@ -58,7 +58,7 @@ export default function ResultScreen({ result, round, totalRounds, onNext }) {
         <div className="map-panel">
           <Map
             style={{ width: '100%', height: '100%' }}
-            mapId={import.meta.env.VITE_GOOGLE_MAPS_MAP_ID}
+            mapId={import.meta.env.PUBLIC_GOOGLE_MAPS_MAP_ID}
             defaultCenter={restaurant}
             defaultZoom={13}
             gestureHandling="cooperative"


### PR DESCRIPTION
VITE_ vars aren't exposed to the client bundle in Astro — PUBLIC_ is required.